### PR TITLE
Correcting array example in the readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ BOOL isMatch = [@"2345" isMatch:RX(@"^\\d+$")];
 NSString* age = [@"My dog is 3." firstMatch:RX(@"\\d+")];
 
 //Get matches as a string array
-NSString* words = [@"Hey pal" firstMatch:RX(@"\\w+")];
+NSArray* words = [@"Hey pal" match:RX(@"\\w+")];
 // words => @[ @"Hey", @"pal" ]
 
 //Get first match with details


### PR DESCRIPTION
The example for `Get matches as a string array` was wrong.
